### PR TITLE
Blur puzzle solutions until revealed

### DIFF
--- a/app/solutions/page.tsx
+++ b/app/solutions/page.tsx
@@ -18,7 +18,7 @@ export default function Solutions() {
 
     const puzzleSolutions: PuzzleSolution[] = [
         {
-            title: 'Down the Aisle',
+            title: 'Matri-Mini Crossword',
             image: solutionMini,
         },
         {

--- a/app/solutions/page.tsx
+++ b/app/solutions/page.tsx
@@ -7,7 +7,7 @@ import solutionMini from "../images/solution_mini.png";
 import solutionConnections from "../images/solution_connections.png";
 import solutionBee from "../images/solution_bee.png";
 import solutionStrands from "../images/solution_strands.png";
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 
 interface PuzzleSolution {
     title: string;
@@ -34,19 +34,40 @@ export default function Solutions() {
             image: solutionStrands,
         },
     ];
+    
+    // Track which solutions have been revealed
+    const [revealedSolutions, setRevealedSolutions] = useState<boolean[]>(
+        new Array(puzzleSolutions.length).fill(false)
+    );
+
+    // Toggle reveal state when an image is clicked
+    const toggleReveal = (index: number) => {
+        const newRevealedSolutions = [...revealedSolutions];
+        newRevealedSolutions[index] = !newRevealedSolutions[index];
+        setRevealedSolutions(newRevealedSolutions);
+    };
 
     return (
         <HomeLayout headerImageSrc="engagement/Hannah-Jack-ENG-AKP-6.17.24-196.jpg">
-            {puzzleSolutions.map(s => (
+            {puzzleSolutions.map((s, index) => (
                 <Fragment key={s.title}>
                     <h1 className="text-2xl font-extrabold text-[#879b88]">{s.title}</h1>
-                    <Image
-                        src={s.image}
-                        width={500}
-                        alt={`Solution for the ${s.title} puzzle`}
-                        className="object-cover pb-10"
-                        priority
-                    />
+                    <div className="relative cursor-pointer" onClick={() => toggleReveal(index)}>
+                        <Image
+                            src={s.image}
+                            width={500}
+                            alt={`Solution for the ${s.title} puzzle`}
+                            className={`object-cover pb-10 transition-all duration-300 ${!revealedSolutions[index] ? 'blur-lg' : ''}`}
+                            priority
+                        />
+                        {!revealedSolutions[index] && (
+                            <div className="absolute inset-0 flex items-center justify-center pb-10">
+                                <span className="bg-[#879b88] text-white px-4 py-2 rounded-md shadow">
+                                    Click to reveal solution
+                                </span>
+                            </div>
+                        )}
+                    </div>
                 </Fragment>
             ))}
         </HomeLayout>


### PR DESCRIPTION
Puzzle solutions are blurred at first and revealed after the user clicks/taps on them. This helps avoid spoilers if someone wants to see the solution for one puzzle without seeing the rest.

Also update the name of the mini crossword to match the programs ("Matri-Mini Crossword")